### PR TITLE
Change ansible_hosts to use DNS names

### DIFF
--- a/ansible/fosdem_hosts
+++ b/ansible/fosdem_hosts
@@ -2,3 +2,4 @@
 
 [event-primary]
 conference.fosdem.net
+ansible_host=151.216.191.253

--- a/ansible/fosdem_hosts
+++ b/ansible/fosdem_hosts
@@ -1,4 +1,4 @@
 [website]
 
 [event-primary]
-151.216.191.253
+conference.fosdem.net

--- a/ansible/fosdem_hosts
+++ b/ansible/fosdem_hosts
@@ -1,5 +1,4 @@
 [website]
 
 [event-primary]
-conference.fosdem.net
-ansible_host=151.216.191.253
+conference.fosdem.net ansible_host=151.216.191.253


### PR DESCRIPTION
Name --> IP mappings should only be in zone files. This change allows people to
use 'host *.fosdem.net' in their SSH configurations etc, and have it work
correctly with ansible.