### PR TITLE
more robust reboot process

### DIFF
--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -7,6 +7,12 @@
   remote_user: root
   gather_facts: False
   pre_tasks:
+  - name: Verify Ansible meets version requirements.
+    assert:
+      that: "ansible_version.full is version_compare('2.7', '>=')"
+      msg: >
+        "You must update Ansible to at least 2.7."
+
   - name: install ansible dependencies (python)
     raw: test -e /usr/bin/python || (apt-get -y update && apt-get install -y python-minimal python-pkg-resources) # install pkg-resources to avoid needlesly triggering the next test
     changed_when: false # raw has no change handler

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -32,16 +32,9 @@
     changed_when: false
 
   - name: reboot the box if needed
-    shell: sleep 2 && shutdown -r now "ansible dependencies installed"
-    async: 1
-    poll: 0
-    ignore_errors: true
+    reboot:
+      msg: "ansible dependencies installed"
     when: systemd_install.changed or pid1.stat.lnk_source != "/lib/systemd/systemd"
-
-  - name: waiting for the box to come back if it has been rebooted
-    local_action: wait_for host={{ ansible_ssh_host | default(inventory_hostname) }} port=22 connect_timeout=5 delay=15 timeout=120 state=started
-    when: systemd_install.changed or pid1.stat.lnk_source != "/lib/systemd/systemd"
-
 
 
 ###


### PR DESCRIPTION
Ansible 2.7 ships with [`reboot` module ](https://docs.ansible.com/ansible/latest/modules/reboot_module.html) which greatly simplifies rebooting machines with ansible and makes this process less error prone.