### PR TITLE
Add tools for hardware raid

### DIFF
--- a/ansible/playbooks/roles/hwraid/defaults/main.yml
+++ b/ansible/playbooks/roles/hwraid/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+hwraid_packages:
+- megacli

--- a/ansible/playbooks/roles/hwraid/tasks/main.yml
+++ b/ansible/playbooks/roles/hwraid/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+# Install hwraid packages from https://hwraid.le-vert.net/wiki/DebianPackages
+
+- name: Install gpg key
+  apt_key:
+    url: https://hwraid.le-vert.net/debian/hwraid.le-vert.net.gpg.key
+
+- name: Install apt repo
+  apt_repository:
+    filename: hwraid
+    repo: "deb http://hwraid.le-vert.net/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
+
+- name: Install hwraid packages
+  apt:
+    package: "{{ hwraid_packages }}"

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -127,9 +127,17 @@
   tags: [event-primary]
   roles:
   - event-primary
+  - hwraid
   - rsyslog
   - debops.dhcpd
   - oxidized
+
+- name: event-secondary
+  hosts: event-secondary
+  remote_user: root
+  tags: [event-secondary]
+  roles:
+  - hwraid
 
 - name: Event Prometheus servers
   hosts: event-prometheus-servers


### PR DESCRIPTION
* Add new hwraid role that installs megacli by default.
* Install hwraid role on event-primary and event-secondary servers.