### PR TITLE
Use multi-index SNMP generator

### DIFF
--- a/ansible/playbooks/templates/snmp_exporter/generator.yml
+++ b/ansible/playbooks/templates/snmp_exporter/generator.yml
@@ -3,7 +3,7 @@ modules:
     auth:
       community: "{{ snmp_community_fosdem_default }}"
     walk:
-    - system
+    - 1.3.6.1.2.1.1 # system, conflict with PowerNet-MIB
     - ifTable
     - etherStatsTable
     - ifXTable
@@ -19,17 +19,22 @@ modules:
     #- cefcFRUPowerSupplyGroupTable
     #- cefcFRUPowerStatusTable
     lookups:
-    - old_index: ifIndex
-      new_index: ifAlias
-    - old_index: ifIndex
-      new_index: ifDescr
-    - old_index: ifIndex
+    - source_indexes: [ ifIndex ]
+      lookup: ifAlias
+      keep_source_indexes: true
+    - source_indexes: [ ifIndex ]
+      lookup: ifDescr
+      keep_source_indexes: true
+    - source_indexes: [ ifIndex ]
       # Use OID to avoid conflict with Netscaler NS-ROOT-MIB.
-      new_index: 1.3.6.1.2.1.31.1.1.1.1 # ifName
-    - old_index: ciscoEnvMonTemperatureStatusIndex
-      new_index: ciscoEnvMonTemperatureStatusDescr
-    - old_index: ciscoEnvMonTemperatureStatusIndex
-      new_index: ciscoEnvMonSupplyStatusDescr
+      lookup: 1.3.6.1.2.1.31.1.1.1.1 # ifName
+      keep_source_indexes: true
+    - source_indexes: [ ciscoEnvMonTemperatureStatusIndex ]
+      lookup: ciscoEnvMonTemperatureStatusDescr
+      keep_source_indexes: true
+    - source_indexes: [ ciscoEnvMonTemperatureStatusIndex ]
+      lookup: ciscoEnvMonSupplyStatusDescr
+      keep_source_indexes: true
   cisco-rogue-ap-table:
     walk:
       - bsnRogueAPDot11MacAddress
@@ -37,13 +42,14 @@ modules:
       - bsnRogueAPDetectingAPMacAddress
       - bsnRogueAPTotalClients
     lookups:
-    - old_index: bsnRogueAPDot11MacAddress
-      new_index: bsnRogueAPSSID
+    - source_indexes: [ bsnRogueAPDot11MacAddress ]
+      lookup: bsnRogueAPSSID
+      keep_source_indexes: true
   cisco_wlc:
     auth:
       community: "{{ snmp_community_ulb_wlc }}"
     walk:
-    - system
+    - 1.3.6.1.2.1.1 # system, conflict with PowerNet-MIB
     - ifXTable
     # Single entries from bsnDot11EssTable # 1.3.6.1.4.1.14179.2.1.1
     - bsnDot11EssSsid
@@ -60,14 +66,19 @@ modules:
       bsnAPName:
         type: DisplayString
     lookups:
-    - old_index: ifIndex
-      new_index: ifAlias
-    - old_index: ifIndex
-      new_index: ifDescr
-    - old_index: ifIndex
+    - source_indexes: [ ifIndex ]
+      lookup: ifAlias
+      keep_source_indexes: true
+    - source_indexes: [ ifIndex ]
+      lookup: ifDescr
+      keep_source_indexes: true
+    - source_indexes: [ ifIndex ]
       # Use OID to avoid conflict with Netscaler NS-ROOT-MIB.
-      new_index: 1.3.6.1.2.1.31.1.1.1.1 # ifName
-    - old_index: bsnAPDot3MacAddress
-      new_index: bsnAPName
-    - old_index: bsnDot11EssIndex
-      new_index: bsnDot11EssSsid
+      lookup: 1.3.6.1.2.1.31.1.1.1.1 # ifName
+      keep_source_indexes: true
+    - source_indexes: [ bsnAPDot3MacAddress ]
+      lookup: bsnAPName
+      keep_source_indexes: true
+    - source_indexes: [ bsnDot11EssIndex ]
+      lookup: bsnDot11EssSsid
+      keep_source_indexes: true

--- a/ansible/playbooks/templates/snmp_exporter/snmp.yml
+++ b/ansible/playbooks/templates/snmp_exporter/snmp.yml
@@ -986,7 +986,7 @@ cisco_wlc:
       type: DisplayString
   - name: bsnAPIfSniffServerIPAddress
     oid: 1.3.6.1.4.1.14179.2.2.2.1.19
-    type: IpAddr
+    type: InetAddressIPv4
     help: The machine ip address on which Airopeek application is running. - 1.3.6.1.4.1.14179.2.2.2.1.19
     indexes:
     - labelname: bsnAPDot3MacAddress
@@ -1342,9 +1342,6 @@ cisco_wlc:
       type: DisplayString
   auth:
     community: '{{ snmp_community_ulb_wlc }}'
-    security_level: noAuthNoPriv
-    auth_protocol: MD5
-    priv_protocol: DES
 if_mib:
   walk:
   - 1.3.6.1.2.1.1
@@ -2785,6 +2782,3 @@ if_mib:
       type: gauge
   auth:
     community: '{{ snmp_community_fosdem_default }}'
-    security_level: noAuthNoPriv
-    auth_protocol: MD5
-    priv_protocol: DES


### PR DESCRIPTION
Update generator to use new multi-index capable style.
* Workaround conflict in `system` name in PowerNet MIB.
* Re-run generator to fix minor MIB reading improvements.