### PR TITLE
Additional split of WLC metrics.

### DIFF
--- a/ansible/group_vars/event-prometheus-servers/prometheus.yml
+++ b/ansible/group_vars/event-prometheus-servers/prometheus.yml
@@ -58,15 +58,15 @@ prometheus_scrape_configs:
     target_label: instance
   - target_label: __address__
     replacement: 127.0.0.1:9116  # SNMP exporter.
-- job_name: 'snmp_wlc_if'
-  scrape_interval: 30s
+- job_name: 'snmp_wlc_base'
+  scrape_interval: 15s
   scrape_timeout: 10s
   static_configs:
     - targets:
       - 172.33.17.250
   metrics_path: /snmp
   params:
-    module: [cisco_wlc_if]
+    module: [cisco_wlc_base]
   relabel_configs:
   - source_labels: [__address__]
     target_label: __param_target

--- a/ansible/playbooks/templates/snmp_exporter/generator.yml
+++ b/ansible/playbooks/templates/snmp_exporter/generator.yml
@@ -45,13 +45,18 @@ modules:
     - source_indexes: [ bsnRogueAPDot11MacAddress ]
       lookup: bsnRogueAPSSID
       keep_source_indexes: true
-  cisco_wlc_if:
+  cisco_wlc_base:
     auth:
       community: "{{ snmp_community_ulb_wlc }}"
     walk:
     - 1.3.6.1.2.1.1 # system, conflict with PowerNet-MIB
     - ifTable
     - ifXTable
+    # AIRESPACE-SWITCHING-MIB
+    - agentResourceInfoGroup
+    # Single entries from bsnDot11EssTable # 1.3.6.1.4.1.14179.2.1.1
+    - bsnDot11EssSsid
+    - bsnDot11EssNumberOfMobileStations
     lookups:
     - source_indexes: [ ifIndex ]
       lookup: ifAlias
@@ -63,28 +68,29 @@ modules:
       # Use OID to avoid conflict with Netscaler NS-ROOT-MIB.
       lookup: 1.3.6.1.2.1.31.1.1.1.1 # ifName
       keep_source_indexes: true
+    - source_indexes: [ bsnDot11EssIndex ]
+      lookup: bsnDot11EssSsid
+      keep_source_indexes: true
   cisco_wlc_wifi:
     auth:
       community: "{{ snmp_community_ulb_wlc }}"
     walk:
-    # Single entries from bsnDot11EssTable # 1.3.6.1.4.1.14179.2.1.1
-    - bsnDot11EssSsid
-    - bsnDot11EssNumberOfMobileStations
-    - bsnAPName
-    - bsnAPIfLoadChannelUtilization
+    # bsnAPEntry
+    - bsnAPName # 1.3.6.1.4.1.14179.2.2.1.1.3 - 30ms
+    - bsnAPAdminStatus # 1.3.6.1.4.1.14179.2.2.1.1.37 - 30ms
+    - bsnAPOperationStatus # 1.3.6.1.4.1.14179.2.2.1.1.6 - 30ms
+    # bsnAPIfLoadParametersTable
+    - bsnAPIfLoadChannelUtilization # 1.3.6.1.4.1.14179.2.2.13.1.3 - 42ms
     # Other tables
-    - bsnAPIfChannelNoiseInfoTable
-    - bsnAPIfDot11CountersTable
-    - bsnAPIfTable # 1.3.6.1.4.1.14179.2.2.2
+    - bsnAPIfChannelNoiseInfoTable # 1.3.6.1.4.1.14179.2.2.15 - 1.2s
+    - bsnAPIfDot11CountersTable # 1.3.6.1.4.1.14179.2.2.6 - 650ms
+    - bsnAPIfTable # 1.3.6.1.4.1.14179.2.2.2 - 1.0s
     # Single entries from bsnAPIfSmtParamTable
-    - bsnAPIfDot11BSSID
+    - bsnAPIfDot11BSSID # 1.3.6.1.4.1.14179.2.2.3.1.30 - 50ms
     overrides:
       bsnAPName:
         type: DisplayString
     lookups:
     - source_indexes: [ bsnAPDot3MacAddress ]
       lookup: bsnAPName
-      keep_source_indexes: true
-    - source_indexes: [ bsnDot11EssIndex ]
-      lookup: bsnDot11EssSsid
       keep_source_indexes: true

--- a/ansible/playbooks/templates/snmp_exporter/snmp.yml
+++ b/ansible/playbooks/templates/snmp_exporter/snmp.yml
@@ -63,11 +63,14 @@ cisco-rogue-ap-table:
       labelname: bsnRogueAPSSID
       oid: 1.3.6.1.4.1.14179.2.1.7.1.11
       type: DisplayString
-cisco_wlc_if:
+cisco_wlc_base:
   walk:
   - 1.3.6.1.2.1.1
   - 1.3.6.1.2.1.2.2
   - 1.3.6.1.2.1.31.1.1
+  - 1.3.6.1.4.1.14179.1.1.5
+  - 1.3.6.1.4.1.14179.2.1.1.1.2
+  - 1.3.6.1.4.1.14179.2.1.1.1.38
   metrics:
   - name: sysDescr
     oid: 1.3.6.1.2.1.1.1
@@ -1088,19 +1091,18 @@ cisco_wlc_if:
       labelname: ifName
       oid: 1.3.6.1.2.1.31.1.1.1.1
       type: DisplayString
-  auth:
-    community: '{{ snmp_community_ulb_wlc }}'
-cisco_wlc_wifi:
-  walk:
-  - 1.3.6.1.4.1.14179.2.1.1.1.2
-  - 1.3.6.1.4.1.14179.2.1.1.1.38
-  - 1.3.6.1.4.1.14179.2.2.1.1.3
-  - 1.3.6.1.4.1.14179.2.2.13.1.3
-  - 1.3.6.1.4.1.14179.2.2.15
-  - 1.3.6.1.4.1.14179.2.2.2
-  - 1.3.6.1.4.1.14179.2.2.3.1.30
-  - 1.3.6.1.4.1.14179.2.2.6
-  metrics:
+  - name: agentCurrentCPUUtilization
+    oid: 1.3.6.1.4.1.14179.1.1.5.1
+    type: gauge
+    help: Current CPU Load of the switch in percentage. - 1.3.6.1.4.1.14179.1.1.5.1
+  - name: agentTotalMemory
+    oid: 1.3.6.1.4.1.14179.1.1.5.2
+    type: gauge
+    help: Total RAM of the switch in Kbytes. - 1.3.6.1.4.1.14179.1.1.5.2
+  - name: agentFreeMemory
+    oid: 1.3.6.1.4.1.14179.1.1.5.3
+    type: gauge
+    help: Free RAM of the switch in Kbytes. - 1.3.6.1.4.1.14179.1.1.5.3
   - name: bsnDot11EssSsid
     oid: 1.3.6.1.4.1.14179.2.1.1.1.2
     type: DisplayString
@@ -1127,10 +1129,51 @@ cisco_wlc_wifi:
       labelname: bsnDot11EssSsid
       oid: 1.3.6.1.4.1.14179.2.1.1.1.2
       type: DisplayString
+  auth:
+    community: '{{ snmp_community_ulb_wlc }}'
+cisco_wlc_wifi:
+  walk:
+  - 1.3.6.1.4.1.14179.2.2.1.1.3
+  - 1.3.6.1.4.1.14179.2.2.1.1.37
+  - 1.3.6.1.4.1.14179.2.2.1.1.6
+  - 1.3.6.1.4.1.14179.2.2.13.1.3
+  - 1.3.6.1.4.1.14179.2.2.15
+  - 1.3.6.1.4.1.14179.2.2.2
+  - 1.3.6.1.4.1.14179.2.2.3.1.30
+  - 1.3.6.1.4.1.14179.2.2.6
+  metrics:
   - name: bsnAPName
     oid: 1.3.6.1.4.1.14179.2.2.1.1.3
     type: DisplayString
     help: Name assigned to this AP - 1.3.6.1.4.1.14179.2.2.1.1.3
+    indexes:
+    - labelname: bsnAPDot3MacAddress
+      type: PhysAddress48
+      fixed_size: 6
+    lookups:
+    - labels:
+      - bsnAPDot3MacAddress
+      labelname: bsnAPName
+      oid: 1.3.6.1.4.1.14179.2.2.1.1.3
+      type: DisplayString
+  - name: bsnAPAdminStatus
+    oid: 1.3.6.1.4.1.14179.2.2.1.1.37
+    type: gauge
+    help: Admin State of the AP - 1.3.6.1.4.1.14179.2.2.1.1.37
+    indexes:
+    - labelname: bsnAPDot3MacAddress
+      type: PhysAddress48
+      fixed_size: 6
+    lookups:
+    - labels:
+      - bsnAPDot3MacAddress
+      labelname: bsnAPName
+      oid: 1.3.6.1.4.1.14179.2.2.1.1.3
+      type: DisplayString
+  - name: bsnAPOperationStatus
+    oid: 1.3.6.1.4.1.14179.2.2.1.1.6
+    type: gauge
+    help: Operation State of the AP - 1.3.6.1.4.1.14179.2.2.1.1.6
     indexes:
     - labelname: bsnAPDot3MacAddress
       type: PhysAddress48


### PR DESCRIPTION
* Rename "if" job to "base"
* Add controller CPU/Memory
* Add AP Admin/Oper status.
* Increase frequency of base stats.
* Move bsnDot11EssTable into base stats (cheap).
* Document timing for various OIDs.