### PR TITLE
Move ssd pid tool to script

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -26,6 +26,6 @@ rules:
     indent-sequences: false
   line-length:
     max: 160
-    level: warning
+    level: error
   truthy:
     level: error

--- a/ansible/playbooks/roles/video-box/tasks/configure_ssd.yml
+++ b/ansible/playbooks/roles/video-box/tasks/configure_ssd.yml
@@ -13,8 +13,16 @@
     fstype: ext4
     dev: "{{ ssd_drive }}"
 
+- name: deploy a stop process tool
+  template:
+    src: video-box/stop_ssd_procs.sh.j2
+    dest: /usr/local/bin/stop_ssd_procs.sh
+    mode: 0755
+    owner: root
+    group: root
+
 - name: stop processes using the SSD
-  shell: lsof | grep /mnt/ssd/ | sed 's/\s\s*/ /g' | cut -d' ' -f 2 | sort -u | while read line; do systemctl stop `systemctl status $line | head -n 1 | cut -d' ' -f 2`; done;
+  shell: /usr/local/sbin/stop_ssd_procs.sh
   when:
   - destroy_all_videobox_data is defined
   - destroy_all_videobox_data == True

--- a/ansible/playbooks/roles/video-box/templates/video-box/stop_ssd_procs.sh.j2
+++ b/ansible/playbooks/roles/video-box/templates/video-box/stop_ssd_procs.sh.j2
@@ -1,0 +1,13 @@
+#!/bin/bash
+{{ ansible_managed | comment }}
+#
+# Description: Shutodwn all processes using the mounted SSD.
+
+lsof |
+  grep /mnt/ssd/ |
+  sed 's/\s\s*/ /g' |
+  cut -d' ' -f 2 |
+  sort -u |
+  while read line; do
+    systemctl stop $(systemctl status "${line}" | head -n 1 | cut -d' ' -f 2)
+  done


### PR DESCRIPTION
Move the ssd process stopper script to a remote file.
* Eliminates a big long shell blob.
* Makes it easy to run the same command manually on the box.