### PR TITLE
Add role for installing sproxy

### DIFF
--- a/ansible/group_vars/video.yml
+++ b/ansible/group_vars/video.yml
@@ -44,5 +44,3 @@ video_rooms:
 - ud2208
 - ud2218a
 - spare0
-
-sproxy_release: v0.2.1

--- a/ansible/playbooks/roles/sproxy/defaults/main.yml
+++ b/ansible/playbooks/roles/sproxy/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+sproxy_version: 0.2.2

--- a/ansible/playbooks/roles/sproxy/tasks/main.yml
+++ b/ansible/playbooks/roles/sproxy/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+- name: "Get checksum for {{ sproxy_arch }} architecture"
+  set_fact:
+    sproxy_checksum: "{{ item.split(' ')[0] }}"
+  with_items:
+  - "{{ lookup('url', 'https://github.com/FOSDEM/video-sproxy/releases/download/v' + sproxy_version + '/sha256sums.txt', wantlist=True) | list }}"
+  when:
+  - "(sproxy_arch + '.tar.gz') in item"
+
+- name: download archive to local folder
+  become: false
+  get_url:
+    url: "https://github.com/FOSDEM/video-sproxy/releases/download/v{{ sproxy_version }}/sproxy-{{ sproxy_version }}.{{ sproxy_arch }}.tar.gz"
+    dest: "/tmp/sproxy-{{ sproxy_version }}.{{ sproxy_arch }}.tar.gz"
+    checksum: "sha256:{{ sproxy_checksum }}"
+  register: _sproxy_download_archive
+  until: _sproxy_download_archive is succeeded
+  retries: 5
+  delay: 2
+  # run_once: true # <-- this cannot be set due to multi-arch support
+  delegate_to: localhost
+  check_mode: false
+
+- name: make an unpack dir
+  file:
+    path: "/tmp/sproxy-v{{ sproxy_version }}.{{ sproxy_arch }}"
+    state: directory
+    mode: 0755
+  delegate_to: localhost
+  check_mode: false
+
+- name: unpack binary
+  become: false
+  unarchive:
+    src: "/tmp/sproxy-v{{ sproxy_version }}.{{ sproxy_arch }}.tar.gz"
+    dest: "/tmp/sproxy-v{{ sproxy_version }}.{{ sproxy_arch }}"
+    creates: "/tmp/sproxy-v{{ sproxy_version }}.{{ sproxy_arch }}/sproxy"
+  delegate_to: localhost
+  check_mode: false
+
+- name: propagate binary
+  copy:
+    src: "/tmp/sproxy-v{{ sproxy_version }}.{{ sproxy_arch }}/sproxy"
+    dest: /usr/local/bin/sproxy
+    mode: 0755
+    owner: root
+    group: root

--- a/ansible/playbooks/roles/sproxy/vars/main.yml
+++ b/ansible/playbooks/roles/sproxy/vars/main.yml
@@ -1,0 +1,7 @@
+---
+sproxy_arch_map:
+  x86_64: 'amd64'
+  aarch64: 'arm64'
+  armv7l: 'armhf'
+
+sproxy_arch: "{{ sproxy_arch_map[ansible_architecture] | default(ansible_architecture) }}"

--- a/ansible/playbooks/roles/video-box/tasks/install_video-streamer.yml
+++ b/ansible/playbooks/roles/video-box/tasks/install_video-streamer.yml
@@ -15,15 +15,6 @@
     group: root
     mode: 0755
 
-- name: Unpack sproxy release
-  unarchive:
-    src: "https://github.com/FOSDEM/video-sproxy/releases/download/{{ sproxy_release }}/sproxy-{{ sproxy_release }}.{{ ansible_architecture }}.tar.gz"
-    dest: /usr/local/bin
-    remote_src: true
-    mode: 0755
-    owner: root
-    group: root
-
 - name: create /usr/lib/firmware
   file:
     path: /usr/lib/firmware

--- a/ansible/playbooks/roles/video-voctop/tasks/install_sproxy.yml
+++ b/ansible/playbooks/roles/video-voctop/tasks/install_sproxy.yml
@@ -1,9 +1,0 @@
----
-- name: Unpack sproxy release
-  unarchive:
-    src: "https://github.com/FOSDEM/video-sproxy/releases/download/{{ sproxy_release }}/sproxy-{{ sproxy_release }}.{{ ansible_architecture }}.tar.gz"
-    dest: /usr/local/bin
-    remote_src: true
-    mode: 0755
-    owner: root
-    group: root

--- a/ansible/playbooks/roles/video-voctop/tasks/main.yml
+++ b/ansible/playbooks/roles/video-voctop/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-- include: install_sproxy.yml
 - include: install_voctocore.yml
 - include: install_audio_fetcher.yml
   tags: voctocore

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -54,12 +54,14 @@
   hosts: video-box
   remote_user: root
   roles:
+  - { role: sproxy, tags: [ 'sproxy' ] }
   - { role: video-box, tags: [ 'video-box' ] }
 
 - name: video-voctop
   hosts: video-voctop
   remote_user: root
   roles:
+  - { role: sproxy, tags: [ 'sproxy' ] }
   - { role: laptop, tags: [ 'laptop' ] }
   - { role: power_supply, tags: [ 'power_supply' ] }
   - { role: video-voctop, tags: [ 'video-voctop' ] }


### PR DESCRIPTION
* Reduce copy-paste errors by using a separate installer role.
* Grab checksum from github to verify release.
* Use local download to propgate binary.
* Translate architecture mappings.

Obsoletes: https://github.com/FOSDEM/infrastructure/pull/220