### PR TITLE
Don't enforce pipefail

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -12,5 +12,6 @@ exclude_paths:
 - ansible/playbooks/roles/rsyslog
 
 skip_list:
+- '306'  # Shells that use pipes should set the pipefail option
 - '403'  # Package installs should not use latest
 - '503'  # TODO(Issue 219) Tasks that run when changed should likely be handlers

--- a/ansible/playbooks/roles/video-box/tasks/configure_ssd.yml
+++ b/ansible/playbooks/roles/video-box/tasks/configure_ssd.yml
@@ -1,7 +1,6 @@
 ---
 - name: detect existing partitions on the SSD
   shell: |
-    set -o pipefail
     fdisk -l {{ ssd_drive }} | grep ^\/ | wc -l
   register: number_of_partitions
   changed_when: false

--- a/ansible/playbooks/roles/video-stream-dump/tasks/configure_hdd.yml
+++ b/ansible/playbooks/roles/video-stream-dump/tasks/configure_hdd.yml
@@ -11,7 +11,6 @@
 
 - name: detect existing partitions on the HDD
   shell: |
-    set -o pipefail
     fdisk -l {{ video_stream_dump_hdd }} | grep ^\/ | wc -l
   register: number_of_partitions
   changed_when: false

--- a/ansible/playbooks/roles/video-streamer-backend/tasks/mount_ssd.yml
+++ b/ansible/playbooks/roles/video-streamer-backend/tasks/mount_ssd.yml
@@ -1,7 +1,6 @@
 ---
 - name: detect existing partitions on the SSD
   shell: |
-    set -o pipefail
     fdisk -l {{ ssd_drive }} | grep ^\/ | wc -l
   register: number_of_partitions
   changed_when: false


### PR DESCRIPTION
Don't enforce ansible-lint 306. We expect these commands to ignore
failures.

Fixes: https://github.com/FOSDEM/infrastructure/issues/224

Signed-off-by: Ben Kochie <superq@gmail.com>