### PR TITLE
video-box: larger base bandwidth, allow to peak to 3.5mbps

### DIFF
--- a/ansible/playbooks/roles/video-box/templates/video-streamer/bmd-receiver.sh
+++ b/ansible/playbooks/roles/video-box/templates/video-streamer/bmd-receiver.sh
@@ -2,4 +2,4 @@
 
 LOGFILE="/mnt/ssd/bmd-streamer.log"
 
-/usr/local/bin/bmd-streamer -f /usr/lib/firmware -k 2000 -S hdmi -F 0 2>> ${LOGFILE} | ffmpeg -v error -i - -c copy -f mpegts - | /usr/local/bin/sproxy
+/usr/local/bin/bmd-streamer -f /usr/lib/firmware -k 2500 -K 3500 -S hdmi -F 0 2>> ${LOGFILE} | ffmpeg -v error -i - -c copy -f mpegts - | /usr/local/bin/sproxy


### PR DESCRIPTION
This has some dangerous potential. By doing some calculations, this *should* be fine, but I'd love for some more people to give an opinion.

This basically means "try to keep at 2.5mbps, but go to 3.5mbps top if needed". I think there should be enough bandwidth, and will have a good overall effect on the quality (as we decode, scale and encode it, more information in it would lead to better source for the final encode).