### PR TITLE
fixes for current voctops and sproxy restart

### DIFF
--- a/ansible/playbooks/roles/common/tasks/install_packages.yml
+++ b/ansible/playbooks/roles/common/tasks/install_packages.yml
@@ -24,6 +24,7 @@
     - mediainfo
     - mosh
     - mtr-tiny
+    - needrestart
     - patch
     - screen
     - sipcalc

--- a/ansible/playbooks/roles/sproxy/tasks/main.yml
+++ b/ansible/playbooks/roles/sproxy/tasks/main.yml
@@ -51,3 +51,4 @@
     mode: 0755
     owner: root
     group: root
+  register: sproxy

--- a/ansible/playbooks/roles/video-box/tasks/install_video-streamer.yml
+++ b/ansible/playbooks/roles/video-box/tasks/install_video-streamer.yml
@@ -97,7 +97,7 @@
   service:
     name: bmd-receiver
     state: restarted
-  when: bmdreceiver.changed
+  when: bmdreceiver.changed or sproxy.changed
 
 - name: enable bmd-receiver service
   systemd:

--- a/ansible/playbooks/roles/video-voctop/tasks/install_voctocore.yml
+++ b/ansible/playbooks/roles/video-voctop/tasks/install_voctocore.yml
@@ -105,3 +105,8 @@
   - vocto-sink-output
   - vocto-source-cam
   - vocto-source-slides
+
+- name: restart vocto scripts on sproxy change
+  shell: "echo changed"
+  notify: restart vocto
+  when: sproxy.changed

--- a/ansible/playbooks/roles/video-voctop/tasks/install_voctocore.yml
+++ b/ansible/playbooks/roles/video-voctop/tasks/install_voctocore.yml
@@ -18,6 +18,7 @@
     - python3-gi-cairo
     - rsync
     - avahi-daemon
+    - i965-va-driver-shaders
 
 - name: "install voctomix package from backports"
   apt:


### PR DESCRIPTION
The current hardware seems to have a problem with the free drivers (and seems to be noted in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=910486 ). This is pretty straight-forward, but the other commit is different and will probably be amended, I'm not sure if this is the best way to propagate the change in sproxy to the handlers.