### PR TITLE
Add iDRAC monitoring

### DIFF
--- a/ansible/files/bind/db.n.fosdem.net
+++ b/ansible/files/bind/db.n.fosdem.net
@@ -1,6 +1,7 @@
+; vim: ts=8 et
 $TTL 3600
 @               IN      SOA     conference-ns1.fosdem.net. hostmaster.conference.fosdem.net. (
-                        2019030601 ; serial
+                        2019122701 ; serial
                         600 ; refresh
                         300 ; retry
                         604800 ; expire
@@ -26,6 +27,10 @@ wifi2          IN       A       151.216.191.251
 wifi2          IN       AAAA    2001:67c:1810:f052:702a:6460:9fbb:1d42
 wifidash       IN       CNAME   wifi1
 wifi-kvm       IN       CNAME   wifi2
+
+; iDRAC
+server001-mgmt IN       A       192.168.1.11
+server002-mgmt IN       A       192.168.1.12
 
 ; CNAMEs
 alertmanager   IN       CNAME   server001.fosdem.net.

--- a/ansible/group_vars/event-prometheus-servers/prometheus.yml
+++ b/ansible/group_vars/event-prometheus-servers/prometheus.yml
@@ -34,6 +34,19 @@ prometheus_targets:
   snmp_dhcp_server:
   - targets:
     - asr1k.n.fosdem.net
+  snmp_idrac:
+  - targets:
+    - server001-mgmt.n.fosdem.net
+    - server002-mgmt.n.fosdem.net
+
+# Template to simplify scrape configs.
+fosdem_snmp_relabel_config:
+- source_labels: [__address__]
+  target_label: __param_target
+- source_labels: [__param_target]
+  target_label: instance
+- target_label: __address__
+  replacement: 127.0.0.1:9116  # SNMP exporter.
 
 prometheus_scrape_configs:
 - job_name: "prometheus"
@@ -61,13 +74,7 @@ prometheus_scrape_configs:
   metrics_path: /snmp
   params:
     module: [if_mib]
-  relabel_configs:
-  - source_labels: [__address__]
-    target_label: __param_target
-  - source_labels: [__param_target]
-    target_label: instance
-  - target_label: __address__
-    replacement: 127.0.0.1:9116  # SNMP exporter.
+  relabel_configs: "{{ fosdem_snmp_relabel_config }}"
 - job_name: 'snmp_slow'
   scrape_interval: 90s
   scrape_timeout: 90s
@@ -78,13 +85,7 @@ prometheus_scrape_configs:
   metrics_path: /snmp
   params:
     module: [if_mib]
-  relabel_configs:
-  - source_labels: [__address__]
-    target_label: __param_target
-  - source_labels: [__param_target]
-    target_label: instance
-  - target_label: __address__
-    replacement: 127.0.0.1:9116  # SNMP exporter.
+  relabel_configs: "{{ fosdem_snmp_relabel_config }}"
 - job_name: 'snmp_dhcp_server'
   scrape_interval: 15s
   static_configs:
@@ -94,13 +95,16 @@ prometheus_scrape_configs:
   metrics_path: /snmp
   params:
     module: [cisco_dhcp_server]
-  relabel_configs:
-  - source_labels: [__address__]
-    target_label: __param_target
-  - source_labels: [__param_target]
-    target_label: instance
-  - target_label: __address__
-    replacement: 127.0.0.1:9116  # SNMP exporter.
+  relabel_configs: "{{ fosdem_snmp_relabel_config }}"
+- job_name: 'snmp_idrac'
+  scrape_interval: 60s
+  file_sd_configs:
+  - files:
+    - "/etc/prometheus/file_sd/snmp_idrac.yml"
+  metrics_path: /snmp
+  params:
+    module: [idrac]
+  relabel_configs: "{{ fosdem_snmp_relabel_config }}"
 - job_name: 'snmp_wlc_base'
   scrape_interval: 15s
   scrape_timeout: 10s
@@ -110,13 +114,7 @@ prometheus_scrape_configs:
   metrics_path: /snmp
   params:
     module: [cisco_wlc_base]
-  relabel_configs:
-  - source_labels: [__address__]
-    target_label: __param_target
-  - source_labels: [__param_target]
-    target_label: instance
-  - target_label: __address__
-    replacement: 127.0.0.1:9116  # SNMP exporter.
+  relabel_configs: "{{ fosdem_snmp_relabel_config }}"
 - job_name: 'snmp_wlc_wifi'
   scrape_interval: 30s
   scrape_timeout: 25s
@@ -126,13 +124,7 @@ prometheus_scrape_configs:
   metrics_path: /snmp
   params:
     module: [cisco_wlc_wifi]
-  relabel_configs:
-  - source_labels: [__address__]
-    target_label: __param_target
-  - source_labels: [__param_target]
-    target_label: instance
-  - target_label: __address__
-    replacement: 127.0.0.1:9116  # SNMP exporter.
+  relabel_configs: "{{ fosdem_snmp_relabel_config }}"
 - job_name: 'snmp_wlc_wifi_rf'
   scrape_interval: 30s
   scrape_timeout: 25s
@@ -142,13 +134,7 @@ prometheus_scrape_configs:
   metrics_path: /snmp
   params:
     module: [cisco_wlc_wifi_rf]
-  relabel_configs:
-  - source_labels: [__address__]
-    target_label: __param_target
-  - source_labels: [__param_target]
-    target_label: instance
-  - target_label: __address__
-    replacement: 127.0.0.1:9116  # SNMP exporter.
+  relabel_configs: "{{ fosdem_snmp_relabel_config }}"
 - job_name: 'caddy'
   static_configs:
   - targets:

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -27,6 +27,9 @@
 ### Common roles
 ###
 
+# Workaround for https://github.com/ansible/ansible/issues/57529
+- hosts: all
+
 - name: common roles
   hosts: all
   remote_user: root

--- a/ansible/playbooks/templates/snmp_exporter/generator.yml
+++ b/ansible/playbooks/templates/snmp_exporter/generator.yml
@@ -126,3 +126,62 @@ modules:
     lookups:
     - source_indexes: [bsnAPDot3MacAddress]
       lookup: bsnAPName
+  idrac:
+    walk:
+    - powerSupplyTable
+    - powerUsageCumulativeWattage
+    - coolingDeviceTable
+    - temperatureProbeTable
+    overrides:
+      powerSupplyStatus:
+        type: EnumAsStateSet
+      powerSupplyRedundancy:
+        type: EnumAsStateSet
+      powerSupplyIndex:
+        ignore: true  # Lookup metric
+      powerSupplyName:
+        ignore: true  # Lookup metric
+      coolingDevicechassisIndex:
+        ignore: true  # Lookup metric
+      coolingDeviceIndex:
+        ignore: true  # Lookup metric
+      coolingDeviceLocationName:
+        ignore: true  # Lookup metric
+        type: DisplayString
+      coolingDeviceStateSettings:
+        ignore: true
+      coolingDeviceStateCapabilities:
+        ignore: true
+      coolingDeviceStatus:
+        type: EnumAsStateSet
+      coolingDeviceType:
+        type: EnumAsInfo
+      coolingDeviceSubType:
+        type: EnumAsInfo
+      temperatureProbechassisIndex:
+        ignore: true  # Lookup metric
+      temperatureProbeIndex:
+        ignore: true  # Lookup metric
+      temperatureProbeLocationName:
+        ignore: true  # Lookup metric
+        type: DisplayString
+      temperatureProbeStateCapabilities:
+        ignore: true
+      temperatureProbeStateSettings:
+        ignore: true
+      temperatureProbeStatus:
+        type: EnumAsStateSet
+      temperatureProbeType:
+        type: EnumAsInfo
+    lookups:
+    - source_indexes:
+      - powerSupplyIndex
+      lookup: powerSupplyName
+    - source_indexes:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      lookup: coolingDeviceLocationName
+    - source_indexes:
+      - temperatureProbechassisIndex
+      - temperatureProbeIndex
+      lookup: temperatureProbeLocationName

--- a/ansible/playbooks/templates/snmp_exporter/snmp.yml
+++ b/ansible/playbooks/templates/snmp_exporter/snmp.yml
@@ -2840,6 +2840,546 @@ cisco_wlc_wifi_rf:
       type: DisplayString
   auth:
     community: '{{ snmp_community_ulb_wlc }}'
+idrac:
+  walk:
+  - 1.3.6.1.4.1.15497.1.1.1.8
+  - 1.3.6.1.4.1.674.10892.5.4.600.60.1.7
+  - 1.3.6.1.4.1.674.10892.5.4.700.12
+  - 1.3.6.1.4.1.674.10892.5.4.700.20
+  metrics:
+  - name: powerSupplyStatus
+    oid: 1.3.6.1.4.1.15497.1.1.1.8.1.2
+    type: EnumAsStateSet
+    help: Represents the status of a power supply - 1.3.6.1.4.1.15497.1.1.1.8.1.2
+    indexes:
+    - labelname: powerSupplyIndex
+      type: gauge
+    lookups:
+    - labels:
+      - powerSupplyIndex
+      labelname: powerSupplyName
+      oid: 1.3.6.1.4.1.15497.1.1.1.8.1.4
+      type: DisplayString
+    enum_values:
+      1: powerSupplyNotInstalled
+      2: powerSupplyHealthy
+      3: powerSupplyNoAC
+      4: powerSupplyFaulty
+  - name: powerSupplyRedundancy
+    oid: 1.3.6.1.4.1.15497.1.1.1.8.1.3
+    type: EnumAsStateSet
+    help: Represents the status of a collection of one or more power supplies - 1.3.6.1.4.1.15497.1.1.1.8.1.3
+    indexes:
+    - labelname: powerSupplyIndex
+      type: gauge
+    lookups:
+    - labels:
+      - powerSupplyIndex
+      labelname: powerSupplyName
+      oid: 1.3.6.1.4.1.15497.1.1.1.8.1.4
+      type: DisplayString
+    enum_values:
+      1: powerSupplyRedundancyOK
+      2: powerSupplyRedundancyLost
+  - name: powerUsageCumulativeWattage
+    oid: 1.3.6.1.4.1.674.10892.5.4.600.60.1.7
+    type: gauge
+    help: 0600.0060.0001.0007 This attribute defines the total wattage used (in Watt-hours)
+      by this entity since the date and time specified by the powerUsageCumulativeWattageStartDateName
+      attribute. - 1.3.6.1.4.1.674.10892.5.4.600.60.1.7
+    indexes:
+    - labelname: powerUsageChassisIndex
+      type: gauge
+    - labelname: powerUsageIndex
+      type: gauge
+  - name: coolingDeviceStatus
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.5
+    type: EnumAsStateSet
+    help: 0700.0012.0001.0005 This attribute defines the probe status of the cooling
+      device. - 1.3.6.1.4.1.674.10892.5.4.700.12.1.5
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+    enum_values:
+      1: other
+      2: unknown
+      3: ok
+      4: nonCriticalUpper
+      5: criticalUpper
+      6: nonRecoverableUpper
+      7: nonCriticalLower
+      8: criticalLower
+      9: nonRecoverableLower
+      10: failed
+  - name: coolingDeviceReading
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.6
+    type: gauge
+    help: 0700.0012.0001.0006 This attribute defines the reading for a cooling device
+      of subtype other than coolingDeviceSubTypeIsDiscrete - 1.3.6.1.4.1.674.10892.5.4.700.12.1.6
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+  - name: coolingDeviceType
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.7
+    type: EnumAsInfo
+    help: 0700.0012.0001.0007 This attribute defines the type of the cooling device.
+      - 1.3.6.1.4.1.674.10892.5.4.700.12.1.7
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+    enum_values:
+      1: coolingDeviceTypeIsOther
+      2: coolingDeviceTypeIsUnknown
+      3: coolingDeviceTypeIsAFan
+      4: coolingDeviceTypeIsABlower
+      5: coolingDeviceTypeIsAChipFan
+      6: coolingDeviceTypeIsACabinetFan
+      7: coolingDeviceTypeIsAPowerSupplyFan
+      8: coolingDeviceTypeIsAHeatPipe
+      9: coolingDeviceTypeIsRefrigeration
+      10: coolingDeviceTypeIsActiveCooling
+      11: coolingDeviceTypeIsPassiveCooling
+  - name: coolingDeviceUpperNonRecoverableThreshold
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.9
+    type: gauge
+    help: 0700.0012.0001.0009 This attribute defines the upper nonrecoverable threshold
+      of the cooling device - 1.3.6.1.4.1.674.10892.5.4.700.12.1.9
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+  - name: coolingDeviceUpperCriticalThreshold
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.10
+    type: gauge
+    help: 0700.0012.0001.0010 This attribute defines the upper critical threshold
+      of the cooling device - 1.3.6.1.4.1.674.10892.5.4.700.12.1.10
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+  - name: coolingDeviceUpperNonCriticalThreshold
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.11
+    type: gauge
+    help: 0700.0012.0001.0011 This attribute defines the upper noncritical threshold
+      of the cooling device - 1.3.6.1.4.1.674.10892.5.4.700.12.1.11
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+  - name: coolingDeviceLowerNonCriticalThreshold
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.12
+    type: gauge
+    help: 0700.0012.0001.0012 This attribute defines the lower noncritical threshold
+      of the cooling device - 1.3.6.1.4.1.674.10892.5.4.700.12.1.12
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+  - name: coolingDeviceLowerCriticalThreshold
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.13
+    type: gauge
+    help: 0700.0012.0001.0013 This attribute defines the lower critical threshold
+      of the cooling device - 1.3.6.1.4.1.674.10892.5.4.700.12.1.13
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+  - name: coolingDeviceLowerNonRecoverableThreshold
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.14
+    type: gauge
+    help: 0700.0012.0001.0014 This attribute defines the lower nonrecoverable threshold
+      of the cooling device - 1.3.6.1.4.1.674.10892.5.4.700.12.1.14
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+  - name: coolingDevicecoolingUnitIndexReference
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.15
+    type: gauge
+    help: 0700.0012.0001.0015 This attribute defines the index to the associated cooling
+      unit. - 1.3.6.1.4.1.674.10892.5.4.700.12.1.15
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+  - name: coolingDeviceSubType
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.16
+    type: EnumAsInfo
+    help: 0700.0012.0001.0016 This attribute defines the subtype of the cooling device.
+      - 1.3.6.1.4.1.674.10892.5.4.700.12.1.16
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+    enum_values:
+      1: coolingDeviceSubTypeIsOther
+      2: coolingDeviceSubTypeIsUnknown
+      3: coolingDeviceSubTypeIsAFanThatReadsInRPM
+      4: coolingDeviceSubTypeIsAFanReadsONorOFF
+      5: coolingDeviceSubTypeIsAPowerSupplyFanThatReadsinRPM
+      6: coolingDeviceSubTypeIsAPowerSupplyFanThatReadsONorOFF
+      16: coolingDeviceSubTypeIsDiscrete
+  - name: coolingDeviceProbeCapabilities
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.17
+    type: gauge
+    help: 0700.0012.0001.0017 This attribute defines the probe capabilities of the
+      cooling device. - 1.3.6.1.4.1.674.10892.5.4.700.12.1.17
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+    enum_values:
+      1: upperNonCriticalThresholdSetCapable
+      2: lowerNonCriticalThresholdSetCapable
+      4: upperNonCriticalThresholdDefaultCapable
+      8: lowerNonCriticalThresholdDefaultCapable
+  - name: coolingDeviceDiscreteReading
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.18
+    type: gauge
+    help: 0700.0012.0001.0018 This attribute defines the reading for a cooling device
+      of type coolingDeviceSubTypeIsDiscrete - 1.3.6.1.4.1.674.10892.5.4.700.12.1.18
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+    enum_values:
+      1: coolingDeviceIsGood
+      2: coolingDeviceIsBad
+  - name: coolingDeviceFQDD
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.19
+    type: OctetString
+    help: 0700.0012.0001.0019 Fully qualified device descriptor (FQDD) of the cooling
+      device. - 1.3.6.1.4.1.674.10892.5.4.700.12.1.19
+    indexes:
+    - labelname: coolingDevicechassisIndex
+      type: gauge
+    - labelname: coolingDeviceIndex
+      type: gauge
+    lookups:
+    - labels:
+      - coolingDevicechassisIndex
+      - coolingDeviceIndex
+      labelname: coolingDeviceLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.12.1.8
+      type: DisplayString
+  - name: temperatureProbeStatus
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.5
+    type: EnumAsStateSet
+    help: 0700.0020.0001.0005 This attribute defines the probe status of the temperature
+      probe. - 1.3.6.1.4.1.674.10892.5.4.700.20.1.5
+    indexes:
+    - labelname: temperatureProbechassisIndex
+      type: gauge
+    - labelname: temperatureProbeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - temperatureProbechassisIndex
+      - temperatureProbeIndex
+      labelname: temperatureProbeLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.8
+      type: DisplayString
+    enum_values:
+      1: other
+      2: unknown
+      3: ok
+      4: nonCriticalUpper
+      5: criticalUpper
+      6: nonRecoverableUpper
+      7: nonCriticalLower
+      8: criticalLower
+      9: nonRecoverableLower
+      10: failed
+  - name: temperatureProbeReading
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.6
+    type: gauge
+    help: 0700.0020.0001.0006 This attribute defines the reading for a temperature
+      probe of type other than temperatureProbeTypeIsDiscrete - 1.3.6.1.4.1.674.10892.5.4.700.20.1.6
+    indexes:
+    - labelname: temperatureProbechassisIndex
+      type: gauge
+    - labelname: temperatureProbeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - temperatureProbechassisIndex
+      - temperatureProbeIndex
+      labelname: temperatureProbeLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.8
+      type: DisplayString
+  - name: temperatureProbeType
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.7
+    type: EnumAsInfo
+    help: 0700.0020.0001.0007 This attribute defines the type of the temperature probe.
+      - 1.3.6.1.4.1.674.10892.5.4.700.20.1.7
+    indexes:
+    - labelname: temperatureProbechassisIndex
+      type: gauge
+    - labelname: temperatureProbeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - temperatureProbechassisIndex
+      - temperatureProbeIndex
+      labelname: temperatureProbeLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.8
+      type: DisplayString
+    enum_values:
+      1: temperatureProbeTypeIsOther
+      2: temperatureProbeTypeIsUnknown
+      3: temperatureProbeTypeIsAmbientESM
+      16: temperatureProbeTypeIsDiscrete
+  - name: temperatureProbeUpperNonRecoverableThreshold
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.9
+    type: gauge
+    help: 0700.0020.0001.0009 This attribute defines the upper nonrecoverable threshold
+      of the temperature probe - 1.3.6.1.4.1.674.10892.5.4.700.20.1.9
+    indexes:
+    - labelname: temperatureProbechassisIndex
+      type: gauge
+    - labelname: temperatureProbeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - temperatureProbechassisIndex
+      - temperatureProbeIndex
+      labelname: temperatureProbeLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.8
+      type: DisplayString
+  - name: temperatureProbeUpperCriticalThreshold
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.10
+    type: gauge
+    help: 0700.0020.0001.0010 This attribute defines the upper critical threshold
+      of the temperature probe - 1.3.6.1.4.1.674.10892.5.4.700.20.1.10
+    indexes:
+    - labelname: temperatureProbechassisIndex
+      type: gauge
+    - labelname: temperatureProbeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - temperatureProbechassisIndex
+      - temperatureProbeIndex
+      labelname: temperatureProbeLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.8
+      type: DisplayString
+  - name: temperatureProbeUpperNonCriticalThreshold
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.11
+    type: gauge
+    help: 0700.0020.0001.0011 This attribute defines the upper noncritical threshold
+      of the temperature probe - 1.3.6.1.4.1.674.10892.5.4.700.20.1.11
+    indexes:
+    - labelname: temperatureProbechassisIndex
+      type: gauge
+    - labelname: temperatureProbeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - temperatureProbechassisIndex
+      - temperatureProbeIndex
+      labelname: temperatureProbeLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.8
+      type: DisplayString
+  - name: temperatureProbeLowerNonCriticalThreshold
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.12
+    type: gauge
+    help: 0700.0020.0001.0012 This attribute defines the lower noncritical threshold
+      of the temperature probe - 1.3.6.1.4.1.674.10892.5.4.700.20.1.12
+    indexes:
+    - labelname: temperatureProbechassisIndex
+      type: gauge
+    - labelname: temperatureProbeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - temperatureProbechassisIndex
+      - temperatureProbeIndex
+      labelname: temperatureProbeLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.8
+      type: DisplayString
+  - name: temperatureProbeLowerCriticalThreshold
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.13
+    type: gauge
+    help: 0700.0020.0001.0013 This attribute defines the lower critical threshold
+      of the temperature probe - 1.3.6.1.4.1.674.10892.5.4.700.20.1.13
+    indexes:
+    - labelname: temperatureProbechassisIndex
+      type: gauge
+    - labelname: temperatureProbeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - temperatureProbechassisIndex
+      - temperatureProbeIndex
+      labelname: temperatureProbeLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.8
+      type: DisplayString
+  - name: temperatureProbeLowerNonRecoverableThreshold
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.14
+    type: gauge
+    help: 0700.0020.0001.0014 This attribute defines the lower nonrecoverable threshold
+      of the temperature probe - 1.3.6.1.4.1.674.10892.5.4.700.20.1.14
+    indexes:
+    - labelname: temperatureProbechassisIndex
+      type: gauge
+    - labelname: temperatureProbeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - temperatureProbechassisIndex
+      - temperatureProbeIndex
+      labelname: temperatureProbeLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.8
+      type: DisplayString
+  - name: temperatureProbeProbeCapabilities
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.15
+    type: gauge
+    help: 0700.0020.0001.0015 This attribute defines the probe capabilities of the
+      temperature probe. - 1.3.6.1.4.1.674.10892.5.4.700.20.1.15
+    indexes:
+    - labelname: temperatureProbechassisIndex
+      type: gauge
+    - labelname: temperatureProbeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - temperatureProbechassisIndex
+      - temperatureProbeIndex
+      labelname: temperatureProbeLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.8
+      type: DisplayString
+    enum_values:
+      1: upperNonCriticalThresholdSetCapable
+      2: lowerNonCriticalThresholdSetCapable
+      4: upperNonCriticalThresholdDefaultCapable
+      8: lowerNonCriticalThresholdDefaultCapable
+  - name: temperatureProbeDiscreteReading
+    oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.16
+    type: gauge
+    help: 0700.0020.0001.0016 This attribute defines the reading for a temperature
+      probe of type temperatureProbeTypeIsDiscrete - 1.3.6.1.4.1.674.10892.5.4.700.20.1.16
+    indexes:
+    - labelname: temperatureProbechassisIndex
+      type: gauge
+    - labelname: temperatureProbeIndex
+      type: gauge
+    lookups:
+    - labels:
+      - temperatureProbechassisIndex
+      - temperatureProbeIndex
+      labelname: temperatureProbeLocationName
+      oid: 1.3.6.1.4.1.674.10892.5.4.700.20.1.8
+      type: DisplayString
+    enum_values:
+      1: temperatureIsGood
+      2: temperatureIsBad
 if_mib:
   walk:
   - 1.3.6.1.2.1.1


### PR DESCRIPTION
* Simplify SNMP relabel configs with template.
* Add server iDRAC addresses to DNS.
* Add idrac targets and scrape configs.
* Add basic iDRAC SNMP walks.

Fixes: https://github.com/FOSDEM/infrastructure/issues/222

Signed-off-by: Ben Kochie <superq@gmail.com>