### PR TITLE
Fix node_exporter startup

### DIFF
--- a/ansible/group_vars/all/default.yml
+++ b/ansible/group_vars/all/default.yml
@@ -20,6 +20,6 @@ node_exporter_textfile_dir: /var/lib/node_exporter
 node_exporter_enabled_collectors:
 - ntp
 - systemd:
-    unit-whitelist: "*.service"
+    unit-whitelist: "'.+\\.service'"
 - textfile:
     directory: "{{ node_exporter_textfile_dir }}"


### PR DESCRIPTION
Fix regexp filter for systemd units.

Fixes: https://github.com/FOSDEM/infrastructure/issues/241

Signed-off-by: Ben Kochie <superq@gmail.com>