### PR TITLE
Enable CoreDNS dns64 plugin

### DIFF
--- a/ansible/group_vars/event-secondary/coredns.yml
+++ b/ansible/group_vars/event-secondary/coredns.yml
@@ -1,3 +1,5 @@
 ---
 coredns_dns_port: 5300
 coredns_config_file: Corefile.j2
+# Custom binary built with dns64 plugin: https://github.com/coredns/coredns/pull/3534
+coredns_binary_local_dir: ~/src/superq/coredns

--- a/ansible/playbooks/templates/Corefile.j2
+++ b/ansible/playbooks/templates/Corefile.j2
@@ -17,6 +17,7 @@ v.conference.fosdem.net {
   prometheus :9153
   log
   cache
+  dns64
   acl {
     # Localhosts
     allow net ::1 127.0.0.0/8


### PR DESCRIPTION
Use a local build of https://github.com/coredns/coredns/pull/3534 to
enable dns64 in CoreDNS.

Signed-off-by: Ben Kochie <superq@gmail.com>