### PR TITLE
Add nftables configuration

### DIFF
--- a/ansible/playbooks/roles/encoder-network/handlers/main.yaml
+++ b/ansible/playbooks/roles/encoder-network/handlers/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: restart nftables
+  systemd:
+    daemon_reload: true
+    name: nftables.service
+    state: restarted

--- a/ansible/playbooks/roles/encoder-network/tasks/main.yaml
+++ b/ansible/playbooks/roles/encoder-network/tasks/main.yaml
@@ -1,0 +1,11 @@
+---
+- name: Ensure nftables is installed
+  apt:
+    package: nftables
+    state: latest
+
+- name: Create nftables config file
+  template:
+    src: nftables.conf.j2
+    dest: /etc/nftables.conf
+  notify: restart nftables

--- a/ansible/playbooks/roles/encoder-network/templates/nftables.conf.j2
+++ b/ansible/playbooks/roles/encoder-network/templates/nftables.conf.j2
@@ -1,0 +1,21 @@
+#!/usr/sbin/nft -f
+
+{{ ansible-managed | comment }}
+
+flush ruleset
+
+table inet filter {
+	chain input {
+		type filter hook input priority filter; policy accept;
+		ip saddr != 10.0.0.0/8 tcp dport 111 drop
+		ip saddr != 10.0.0.0/8 udp dport 111 drop
+	}
+
+	chain forward {
+		type filter hook forward priority filter; policy accept;
+	}
+
+	chain output {
+		type filter hook output priority filter; policy accept;
+	}
+}

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -87,6 +87,7 @@
   hosts: video-streamer-backend
   remote_user: root
   roles:
+  - { role: encoder-network, tags: [ 'encoder-network' ] }
   - { role: video-streamer-backend, tags: [ 'video-streamer-backend' ] }
   - mtail
 
@@ -163,12 +164,14 @@
   hosts: encoder-storage
   remote_user: root
   roles:
+  - { role: encoder-network, tags: [ 'encoder-network' ] }
   - { role: encoder-storage, tags: [ 'encoder-storage'] }
 
 - name: encoder-master
   hosts: encoder-master
   remote_user: root
   roles:
+  - { role: encoder-network, tags: [ 'encoder-network' ] }
   - { role: encoder-common, tags: [ 'encoder-master'] }
   - { role: encoder-master, tags: [ 'encoder-master'] }
 
@@ -176,5 +179,6 @@
   hosts: encoder-backend
   remote_user: root
   roles:
+  - { role: encoder-network, tags: [ 'encoder-network' ] }
   - { role: encoder-common, tags: [ 'encoder-backend'] }
   - { role: encoder-backend, tags: [ 'encoder-backend' ] }


### PR DESCRIPTION
The portmapper service can be used in a DDoS amplification attack. Don't
allow our servers to be misused.

(note: firewalls have been installed currently, but outside of ansible)