### PR TITLE
Simplify common role

### DIFF
--- a/ansible/playbooks/roles/common-repository-debian-backports/tasks/main.yml
+++ b/ansible/playbooks/roles/common-repository-debian-backports/tasks/main.yml
@@ -1,6 +1,0 @@
----
-- name: add debian backports repository
-  apt_repository:
-    repo: "deb http://deb.debian.org/debian {{ ansible_distribution_release }}-backports main contrib non-free"
-    state: present
-    update_cache: true

--- a/ansible/playbooks/roles/common/handlers/main.yml
+++ b/ansible/playbooks/roles/common/handlers/main.yml
@@ -10,3 +10,7 @@
     daemon_reload: true
     name: sshd
     state: reloaded
+
+- name: update apt cache
+  apt:
+    update_cache: true

--- a/ansible/playbooks/roles/common/tasks/configure_apt.yml
+++ b/ansible/playbooks/roles/common/tasks/configure_apt.yml
@@ -6,12 +6,13 @@
     owner: root
     group: root
     mode: 0644
-  register: apt_sources
+  notify:
+  - update apt cache
 
-- name: "run apt update if we have modified the sources"
-  apt:
-    update_cache: true
-  when: apt_sources.changed
+- name: cleanup old backports config
+  apt_repository:
+    repo: "deb http://deb.debian.org/debian {{ ansible_distribution_release }}-backports main contrib non-free"
+    state: absent
 
 - name: "run apt update if the cache is is stale"
   apt:

--- a/ansible/playbooks/roles/common/tasks/main.yml
+++ b/ansible/playbooks/roles/common/tasks/main.yml
@@ -1,14 +1,4 @@
 ---
-- name: Set go arch variable
-  set_fact:
-    go_arch: "amd64"
-  when: ansible_architecture == "x86_64"
-
-- name: Set go arch variable
-  set_fact:
-    go_arch: "armv7"
-  when: ansible_architecture == "armv7l"
-
 - name: get git version
   shell: git log -1 '--date=format:%Y-%m-%d %H:%M' '--pretty=format:%cd %h'  # noqa 303 305
   register: git_version

--- a/ansible/playbooks/roles/common/templates/apt/sources.list.j2
+++ b/ansible/playbooks/roles/common/templates/apt/sources.list.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
 deb http://deb.debian.org/debian/ {{ansible_distribution_release}} main contrib non-free
+deb http://deb.debian.org/debian/ {{ansible_distribution_release}}-backports main contrib non-free
 deb http://deb.debian.org/debian/ {{ansible_distribution_release}}-updates main contrib non-free
 deb http://security.debian.org/ {{ansible_distribution_release}}/updates main contrib non-free

--- a/ansible/playbooks/roles/common/vars/main.yml
+++ b/ansible/playbooks/roles/common/vars/main.yml
@@ -1,0 +1,9 @@
+---
+go_arch_map:
+  i386: '386'
+  x86_64: 'amd64'
+  aarch64: 'arm64'
+  armv7l: 'armv7'
+  armv6l: 'armv6'
+
+go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -35,7 +35,6 @@
   remote_user: root
   tags: [common]
   roles:
-  - common-repository-debian-backports
   - common
   - { role: cloudalchemy.node-exporter, tags: [ 'node_exporter' ] }
 


### PR DESCRIPTION
* Use a handler for updating the apt cache.
* Move backports into the main sources.list.
* Simplify go_arch with a vars expansion instead of set fact tasks.

Signed-off-by: Ben Kochie <superq@gmail.com>