### PR TITLE
Improve DNS64/Dualstack support

### DIFF
--- a/ansible/group_vars/event-primary/coredns.yml
+++ b/ansible/group_vars/event-primary/coredns.yml
@@ -5,10 +5,10 @@ coredns_config_file: Corefile.j2
 coredns_binary_local_dir: ~/src/superq/coredns
 
 fosdem_dns_dns64_addrs:
-- '2001:67c:1810:f054::ffff:6400'
+- '2001:67c:1810:f054::ffff:64'
 
 fosdem_dns_dualstack_addrs:
 - '127.0.0.1'
 - '::1'
-- '185.175.216.252'
-- '2001:67c:1810:f054::ffff:5300'
+- '185.175.216.251'
+- '2001:67c:1810:f054::ffff:53'

--- a/ansible/playbooks/templates/Corefile.j2
+++ b/ansible/playbooks/templates/Corefile.j2
@@ -12,12 +12,34 @@ v.conference.fosdem.net {
   file zones/db.v.conference.fosdem.net
 }
 
-# Recursive forwarding
+# Recursive forwarding DNS64
 . {
   prometheus :9153
+  bind {{ fosdem_dns_dns64_addrs | join(" ") }}
   log
   cache
   dns64
+  acl {
+    # Localhosts
+    allow net ::1 127.0.0.0/8
+{% for subnet, list in fosdem_subnets.items() %}
+    # FOSDEM subnet {{ subnet }}
+    allow net {{ list | join(" ") }}
+{% endfor %}
+    # FOSDEM server private 1918 space
+    allow net 192.168.0.0/16
+    block
+  }
+  # Quad9 unsecured upstream.
+  forward . 2620:fe::10 2620:fe::fe:10
+}
+
+# Recursive forwarding dualstack
+. {
+  prometheus :9153
+  bind {{ fosdem_dns_dualstack_addrs | join(" ") }}
+  log
+  cache
   acl {
     # Localhosts
     allow net ::1 127.0.0.0/8


### PR DESCRIPTION
Split recursive listening to different IPs. One address for Dualstack,
one for DNS64. Allows CoreDNS to handle traffic without need for ACLs.

Signed-off-by: Ben Kochie <superq@gmail.com>