### PR TITLE
Update dhclient config for event servers

### DIFF
--- a/ansible/playbooks/roles/dhclient/tasks/main.yml
+++ b/ansible/playbooks/roles/dhclient/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Fix DHCP client config
-  copy:
+  template:
     src: dhclient.conf
     dest: /etc/dhcp/dhclient.conf

--- a/ansible/playbooks/roles/dhclient/templates/dhclient.conf.j2
+++ b/ansible/playbooks/roles/dhclient/templates/dhclient.conf.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 # Configuration file for /sbin/dhclient.
 #
 # This is a sample configuration file for dhclient. See dhclient.conf's
@@ -18,8 +19,7 @@ request subnet-mask, broadcast-address, interface-mtu, rfc3442-classless-static-
 
 #send dhcp-client-identifier 1:0:a0:24:ab:fb:9c;
 #send dhcp-lease-time 3600;
-supersede domain-name "fosdem.net";
-supersede domain-name-servers 8.8.8.8;
+#supersede domain-name "fugue.com home.vix.com";
 #prepend domain-name-servers 127.0.0.1;
 #require subnet-mask, domain-name-servers;
 #timeout 60;

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -133,6 +133,7 @@
   remote_user: root
   tags: [event-secondary]
   roles:
+  - dhclient
   - hwraid
   - { role: cloudalchemy.coredns, tags: [ 'coredns' ] }
   - { role: fosdem.bind, tags: [ 'dns' ] }


### PR DESCRIPTION
* Don't set DNS settings which update /etc/resolv.conf, this is managed
by /etc/network/interfaces.
* Add dhclient config to secondary server.

Signed-off-by: Ben Kochie <superq@gmail.com>